### PR TITLE
Fix docker build/test by using GitHub Container Registry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,6 +154,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, lint]
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
     
     steps:
     - name: Checkout code
@@ -162,17 +165,48 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}
+        tags: |
+          type=ref,event=branch
+          type=sha,prefix={{branch}}-,format=short,length=10
+          type=raw,value=latest,enable={{is_default_branch}}
+
     - name: Build Docker image
       uses: docker/build-push-action@v6
       with:
         context: .
-        push: false
-        tags: modelplex:latest
+        load: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         platforms: linux/amd64
 
     - name: Test Docker image
       run: |
-        docker run --rm modelplex:latest --version
-        docker run --rm modelplex:latest --help
+        # Test the built image before pushing (using short SHA)
+        SHORT_SHA=$(git rev-parse --short=10 ${{ github.sha }})
+        docker run --rm ghcr.io/${{ github.repository }}:main-${SHORT_SHA} --version
+        docker run --rm ghcr.io/${{ github.repository }}:main-${SHORT_SHA} --help
+
+    - name: Push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/amd64


### PR DESCRIPTION
Complete overhaul of Docker CI/CD to use GitHub Container Registry with test-then-push workflow.

Key improvements:
- GitHub Container Registry integration with ghcr.io/shazow/modelplex 
- Test-then-push strategy ensuring only working images are published
- 10-character commit hashes for better collision resistance
- Multiple tag strategies: latest, main-{short-sha}, main
- Proper GHCR permissions and authentication
- Buildx caching for faster builds

Benefits:
- Reliable builds with no Docker run failures
- Production-ready images tested before publishing  
- Immediate availability for deployment
- Traceability with commit hash tags
- Foundation for container-based distribution